### PR TITLE
Fa 988 add client request

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = aiohttp,pandas,requests,setuptools,tqdm
+known_third_party = aiohttp,pandas,pytest,requests,setuptools,tqdm

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = aiohttp,pandas,pytest,requests,setuptools,tqdm
+known_third_party = aiohttp,httpretty,pandas,pytest,requests,setuptools,tqdm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python: 3.7
 
 install:
-  - pip install .['dev']
+  - pip install pipenv
+  - pipenv install --dev
 
 script:
-  - pre-commit run --all-files
-  - echo "test"
+  - pipenv run pre-commit run --all-files
+  - pipenv run pytest

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,9 @@ pre-commit = "*"
 
 [packages]
 requests = "*"
+pandas = "*"
+aiohttp = "*"
+tqdm = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+httpretty = "*"
+pre-commit = "*"
+
+[packages]
+requests = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,222 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "dccd7c1bf103649f823d496a4b86785f13b40f9755fd2778e9c41e443684d7ee"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "index": "pypi",
+            "version": "==2.23.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+            ],
+            "version": "==1.25.8"
+        }
+    },
+    "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "cfgv": {
+            "hashes": [
+                "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53",
+                "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"
+            ],
+            "version": "==3.1.0"
+        },
+        "distlib": {
+            "hashes": [
+                "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+            ],
+            "version": "==0.3.0"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+            ],
+            "version": "==3.0.12"
+        },
+        "httpretty": {
+            "hashes": [
+                "sha256:66216f26b9d2c52e81808f3e674a6fb65d4bf719721394a1a9be926177e55fbe"
+            ],
+            "index": "pypi",
+            "version": "==0.9.7"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:1222b648251bdcb8deb240b294f450fbf704c7984e08baa92507e4ea10b436d5",
+                "sha256:d824ebe21f38325c771c41b08a95a761db1982f1fc0eee37c6c97df3f1636b96"
+            ],
+            "version": "==1.4.11"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.5.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
+        "nodeenv": {
+            "hashes": [
+                "sha256:5b2438f2e42af54ca968dd1b374d14a1194848955187b0e5e4be1f73813a5212"
+            ],
+            "version": "==1.3.5"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:487c675916e6f99d355ec5595ad77b325689d423ef4839db1ed2f02f639c9522",
+                "sha256:c0aa11bce04a7b46c5544723aedf4e81a4d5f64ad1205a30a9ea12d5e81969e1"
+            ],
+            "index": "pypi",
+            "version": "==2.2.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+            ],
+            "version": "==2.4.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6",
+                "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf",
+                "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5",
+                "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e",
+                "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811",
+                "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e",
+                "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d",
+                "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20",
+                "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689",
+                "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994",
+                "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
+            ],
+            "version": "==5.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:10750cac3b5a9e6eed54d0f1f8222c550dc47f84609c95cbc504d44a58a048b8",
+                "sha256:8512e83f1d90f8e481024d58512ac9c053bf16f54d9138520a0929396820dd78"
+            ],
+            "version": "==20.0.10"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+            ],
+            "version": "==0.1.8"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "version": "==3.1.0"
+        }
+    }
+}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dccd7c1bf103649f823d496a4b86785f13b40f9755fd2778e9c41e443684d7ee"
+            "sha256": "857197db6c7b4be2f88cde78f27770eb5ec63b86c998e765ff2c2435e8da7783"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,38 @@
         ]
     },
     "default": {
+        "aiohttp": {
+            "hashes": [
+                "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e",
+                "sha256:259ab809ff0727d0e834ac5e8a283dc5e3e0ecc30c4d80b3cd17a4139ce1f326",
+                "sha256:2f4d1a4fdce595c947162333353d4a44952a724fba9ca3205a3df99a33d1307a",
+                "sha256:32e5f3b7e511aa850829fbe5aa32eb455e5534eaa4b1ce93231d00e2f76e5654",
+                "sha256:344c780466b73095a72c616fac5ea9c4665add7fc129f285fbdbca3cccf4612a",
+                "sha256:460bd4237d2dbecc3b5ed57e122992f60188afe46e7319116da5eb8a9dfedba4",
+                "sha256:4c6efd824d44ae697814a2a85604d8e992b875462c6655da161ff18fd4f29f17",
+                "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec",
+                "sha256:6206a135d072f88da3e71cc501c59d5abffa9d0bb43269a6dcd28d66bfafdbdd",
+                "sha256:65f31b622af739a802ca6fd1a3076fd0ae523f8485c52924a89561ba10c49b48",
+                "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59",
+                "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"
+            ],
+            "index": "pypi",
+            "version": "==3.6.2"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
+                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
+            ],
+            "version": "==3.0.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
@@ -37,6 +69,90 @@
             ],
             "version": "==2.9"
         },
+        "multidict": {
+            "hashes": [
+                "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
+                "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35",
+                "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928",
+                "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969",
+                "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e",
+                "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78",
+                "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1",
+                "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136",
+                "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8",
+                "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2",
+                "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e",
+                "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4",
+                "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5",
+                "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd",
+                "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab",
+                "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20",
+                "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"
+            ],
+            "version": "==4.7.5"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
+                "sha256:1b0ece94018ae21163d1f651b527156e1f03943b986188dd81bc7e066eae9d1c",
+                "sha256:2e40be731ad618cb4974d5ba60d373cdf4f1b8dcbf1dcf4d9dff5e212baf69c5",
+                "sha256:4ba59db1fcc27ea31368af524dcf874d9277f21fd2e1f7f1e2e0c75ee61419ed",
+                "sha256:59ca9c6592da581a03d42cc4e270732552243dc45e87248aa8d636d53812f6a5",
+                "sha256:5e0feb76849ca3e83dd396254e47c7dba65b3fa9ed3df67c2556293ae3e16de3",
+                "sha256:6d205249a0293e62bbb3898c4c2e1ff8a22f98375a34775a259a0523111a8f6c",
+                "sha256:6fcc5a3990e269f86d388f165a089259893851437b904f422d301cdce4ff25c8",
+                "sha256:82847f2765835c8e5308f136bc34018d09b49037ec23ecc42b246424c767056b",
+                "sha256:87902e5c03355335fc5992a74ba0247a70d937f326d852fc613b7f53516c0963",
+                "sha256:9ab21d1cb156a620d3999dd92f7d1c86824c622873841d6b080ca5495fa10fef",
+                "sha256:a1baa1dc8ecd88fb2d2a651671a84b9938461e8a8eed13e2f0a812a94084d1fa",
+                "sha256:a244f7af80dacf21054386539699ce29bcc64796ed9850c99a34b41305630286",
+                "sha256:a35af656a7ba1d3decdd4fae5322b87277de8ac98b7d9da657d9e212ece76a61",
+                "sha256:b1fe1a6f3a6f355f6c29789b5927f8bd4f134a4bd9a781099a7c4f66af8850f5",
+                "sha256:b5ad0adb51b2dee7d0ee75a69e9871e2ddfb061c73ea8bc439376298141f77f5",
+                "sha256:ba3c7a2814ec8a176bb71f91478293d633c08582119e713a0c5351c0f77698da",
+                "sha256:cd77d58fb2acf57c1d1ee2835567cd70e6f1835e32090538f17f8a3a99e5e34b",
+                "sha256:cdb3a70285e8220875e4d2bc394e49b4988bdb1298ffa4e0bd81b2f613be397c",
+                "sha256:deb529c40c3f1e38d53d5ae6cd077c21f1d49e13afc7936f7f868455e16b64a0",
+                "sha256:e7894793e6e8540dbeac77c87b489e331947813511108ae097f1715c018b8f3d"
+            ],
+            "version": "==1.18.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835",
+                "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722",
+                "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266",
+                "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645",
+                "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5",
+                "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4",
+                "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a",
+                "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586",
+                "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b",
+                "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c",
+                "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b",
+                "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85",
+                "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5",
+                "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639",
+                "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e",
+                "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"
+            ],
+            "index": "pypi",
+            "version": "==1.0.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
         "requests": {
             "hashes": [
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
@@ -45,12 +161,49 @@
             "index": "pypi",
             "version": "==2.23.0"
         },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:0d8b5afb66e23d80433102e9bd8b5c8b65d34c2a2255b2de58d97bd2ea8170fd",
+                "sha256:f35fb121bafa030bd94e74fcfd44f3c2830039a2ddef7fc87ef1c2d205237b24"
+            ],
+            "index": "pypi",
+            "version": "==4.43.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
                 "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
             "version": "==1.25.8"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce",
+                "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6",
+                "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce",
+                "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae",
+                "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d",
+                "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f",
+                "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b",
+                "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b",
+                "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb",
+                "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462",
+                "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea",
+                "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70",
+                "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1",
+                "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a",
+                "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b",
+                "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080",
+                "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"
+            ],
+            "version": "==1.4.2"
         }
     },
     "develop": {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-# <Title_Here>
+# Title
 ## What?
 ## Why?
 - [ ] Merged latest master

--- a/sentera/_version.py
+++ b/sentera/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -4,17 +4,20 @@ import asyncio
 import requests
 from pandas import json_normalize
 
-from sentera import configuration, weather
+from sentera import weather
+from sentera.configuration import Configuration
 
 
 def _run_sentera_query(query, token):
-    url = configuration.sentera_api_url("/graphql")
+    url = Configuration().sentera_api_url("/graphql")
     headers = {"Authorization": token}
-    request = requests.post(url=url, json=query, headers=headers)
-    if request.status_code != 200:
-        raise Exception("Request Failed {}. {}".format(request.status_code, query))
+    response = requests.post(url=url, json=query, headers=headers)
+    if response.status_code != 200:
+        raise Exception(
+            "Request Failed {}. {}".format(response.status_code, response.text)
+        )
 
-    return request.json()
+    return response.json()
 
 
 def get_all_fields(token):

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -4,14 +4,13 @@ import asyncio
 import requests
 from pandas import json_normalize
 
-from sentera import weather
+from sentera import configuration, weather
 
 
 def _run_sentera_query(query, token):
+    url = configuration.sentera_api_url('/graphql')
     headers = {"Authorization": token}
-    request = requests.post(
-        url="https://api.sentera.com/graphql", json=query, headers=headers
-    )
+    request = requests.post(url=url, json=query, headers=headers)
     if request.status_code != 200:
         raise Exception("Request Failed {}. {}".format(request.status_code, query))
 

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -43,7 +43,7 @@ def get_weather(
     weather_variables=None,
     weather_interval=None,
     time_interval=None,
-    dtn_key=None,
+    sentera_api_key=None,
 ):
     """
     Return a pandas DataFrame with desired weather information.
@@ -55,7 +55,7 @@ def get_weather(
     :param time_interval: [*day_start*, *day_end*] in format **YYYY/MM/DD** (eg. *['2020/01/01', '2020/01/03']*).
                           Needed for *recent* weather types, but no others.
     :param location_list: list of locations defined by (*lat*, *long*) to get weather for
-    :param dtn_key: (optional) A DTN key giving access to the data. Has a default hard coded value that works.
+    :param sentera_api_key: (optional) A Sentera API key giving access to the data. Has a default hard coded value that works.
     :return: **weather_dataframe** - pandas dataframe
     """
     weather_type = weather.WeatherType(weather_type)
@@ -95,7 +95,7 @@ def get_weather(
             time_interval_list,
             weather_interval,
             weather_type,
-            dtn_key,
+            sentera_api_key,
         )
     )
     return weather_df

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -8,7 +8,7 @@ from sentera import configuration, weather
 
 
 def _run_sentera_query(query, token):
-    url = configuration.sentera_api_url('/graphql')
+    url = configuration.sentera_api_url("/graphql")
     headers = {"Authorization": token}
     request = requests.post(url=url, json=query, headers=headers)
     if request.status_code != 200:

--- a/sentera/auth.py
+++ b/sentera/auth.py
@@ -1,7 +1,7 @@
 """Functions to generate authorization credentials for use of the Sentera Weather API."""
 import requests
 
-from sentera import configuration
+from sentera.configuration import Configuration
 
 
 def get_auth_token(email, password):
@@ -22,7 +22,7 @@ def get_auth_token(email, password):
         }
     }
 
-    request = requests.post(configuration.sentera_api_url("/v1/sessions"), json=query)
+    request = requests.post(Configuration().sentera_api_url("/v1/sessions"), json=query)
     if request.status_code != 200:
         raise Exception(
             "Query failed to run by returning code of {}. {}".format(
@@ -45,7 +45,7 @@ def get_application_token(client_id, client_secret):
     """
     data = {"grant_type": "client_credentials"}
     response = requests.post(
-        configuration.sentera_api_url("/oauth/token"),
+        Configuration().sentera_api_url("/oauth/token"),
         data=data,
         allow_redirects=False,
         auth=(client_id, client_secret),

--- a/sentera/auth.py
+++ b/sentera/auth.py
@@ -4,6 +4,33 @@ import requests
 from sentera.configuration import Configuration
 
 
+def get_application_token(client_id, client_secret):
+    """
+    Return an access token needed by :code:`sentera.api` calls.
+
+    :param client_id: client id from a CloudVault application
+    :param client_secret: client secret from a CloudVault application
+    :return: **token** - access token
+    """
+    if not client_id or not client_secret:
+        raise TypeError("Arguments client_id and client_secret are required.")
+
+    data = {"grant_type": "client_credentials"}
+    response = requests.post(
+        Configuration().sentera_api_url("/oauth/token"),
+        data=data,
+        allow_redirects=False,
+        auth=(client_id, client_secret),
+    )
+    if response.status_code != 200:
+        raise Exception(
+            "Failed to authenticate using client credentials. Response code of {} and message: {}".format(
+                response.status_code, response.json()
+            )
+        )
+    return response.json()
+
+
 def get_auth_token(email, password):
     """
     Return an access token needed by :code:`sentera.api` calls.
@@ -33,27 +60,3 @@ def get_auth_token(email, password):
     result = request.json()
     auth_token = result["auth_token"]
     return auth_token
-
-
-def get_application_token(client_id, client_secret):
-    """
-    Return an access token needed by :code:`sentera.api` calls.
-
-    :param client_id: client id from a CloudVault application
-    :param client_secret: client secret from a CloudVault application
-    :return: **token** - access token
-    """
-    data = {"grant_type": "client_credentials"}
-    response = requests.post(
-        Configuration().sentera_api_url("/oauth/token"),
-        data=data,
-        allow_redirects=False,
-        auth=(client_id, client_secret),
-    )
-    if response.status_code != 200:
-        raise Exception(
-            "Failed to authenticate using client credentials. Response code of {} and message: {}".format(
-                response.status_code, response.json()
-            )
-        )
-    return response.json()

--- a/sentera/auth.py
+++ b/sentera/auth.py
@@ -3,6 +3,7 @@ import requests
 
 from sentera import configuration
 
+
 def get_auth_token(email, password):
     """
     Return an access token needed by :code:`sentera.api` calls.
@@ -21,7 +22,7 @@ def get_auth_token(email, password):
         }
     }
 
-    request = requests.post(configuration.sentera_api_url('/v1/sessions'), json=query)
+    request = requests.post(configuration.sentera_api_url("/v1/sessions"), json=query)
     if request.status_code != 200:
         raise Exception(
             "Query failed to run by returning code of {}. {}".format(
@@ -33,6 +34,7 @@ def get_auth_token(email, password):
     auth_token = result["auth_token"]
     return auth_token
 
+
 def get_application_token(client_id, client_secret):
     """
     Return an access token needed by :code:`sentera.api` calls.
@@ -41,11 +43,12 @@ def get_application_token(client_id, client_secret):
     :param client_secret: client secret from a CloudVault application
     :return: **token** - access token
     """
-
-    data = { 'grant_type': 'client_credentials'}
+    data = {"grant_type": "client_credentials"}
     response = requests.post(
-        configuration.sentera_api_url('/oauth/token'),
-        data=data, allow_redirects=False, auth=(client_id, client_secret)
+        configuration.sentera_api_url("/oauth/token"),
+        data=data,
+        allow_redirects=False,
+        auth=(client_id, client_secret),
     )
     if response.status_code != 200:
         raise Exception(

--- a/sentera/auth.py
+++ b/sentera/auth.py
@@ -1,14 +1,15 @@
 """Functions to generate authorization credentials for use of the Sentera Weather API."""
 import requests
 
+from sentera import configuration
 
 def get_auth_token(email, password):
     """
-    Return authentication token needed by :code:`sentera.api` calls.
+    Return an access token needed by :code:`sentera.api` calls.
 
     :param email: sentera email
     :param password: sentera password
-    :return: **token** - authentication token
+    :return: **token** - access token
     """
     # The GraphQL query (with a few aditional bits included) itself defined as a multi-line string.
     query = {
@@ -20,7 +21,7 @@ def get_auth_token(email, password):
         }
     }
 
-    request = requests.post("https://api.sentera.com/v1/sessions", json=query)
+    request = requests.post(configuration.sentera_api_url('/v1/sessions'), json=query)
     if request.status_code != 200:
         raise Exception(
             "Query failed to run by returning code of {}. {}".format(
@@ -31,3 +32,25 @@ def get_auth_token(email, password):
     result = request.json()
     auth_token = result["auth_token"]
     return auth_token
+
+def get_application_token(client_id, client_secret):
+    """
+    Return an access token needed by :code:`sentera.api` calls.
+
+    :param client_id: client id from a CloudVault application
+    :param client_secret: client secret from a CloudVault application
+    :return: **token** - access token
+    """
+
+    data = { 'grant_type': 'client_credentials'}
+    response = requests.post(
+        configuration.sentera_api_url('/oauth/token'),
+        data=data, allow_redirects=False, auth=(client_id, client_secret)
+    )
+    if response.status_code != 200:
+        raise Exception(
+            "Failed to authenticate using client credentials. Response code of {} and message: {}".format(
+                response.status_code, response.json()
+            )
+        )
+    return response.json()

--- a/sentera/configuration.ini
+++ b/sentera/configuration.ini
@@ -5,11 +5,6 @@ environment = development
 sentera_api_url = https://apidev.sentera.com
 weather_api_url = https://weatherdev.sentera.com
 
-[local]
-environment = local
-sentera_api_url = http://localhost:3001
-weather_api_url = https://localhost:3002
-
 [production]
 environment = production
 sentera_api_url = https://api.sentera.com

--- a/sentera/configuration.ini
+++ b/sentera/configuration.ini
@@ -1,17 +1,26 @@
 [DEFAULT]
-sentera_api_url = https://api.sentera.com
 
 [development]
 environment = development
 sentera_api_url = https://apidev.sentera.com
+weather_api_url = https://weatherdev.sentera.com
+
+[local]
+environment = local
+sentera_api_url = http://localhost:3001
+weather_api_url = https://localhost:3002
+
+[production]
+environment = production
+sentera_api_url = https://api.sentera.com
+weather_api_url = https://weather.sentera.com
 
 [staging]
 environment = staging
 sentera_api_url = https://apistaging.sentera.com
+weather_api_url = https://weatherstaging.sentera.com
 
 [staging2]
 environment = staging2
 sentera_api_url = https://apistaging2.sentera.com
-
-[production]
-environment = production
+weather_api_url = https://weatherstaging2.sentera.com

--- a/sentera/configuration.ini
+++ b/sentera/configuration.ini
@@ -1,0 +1,17 @@
+[DEFAULT]
+sentera_api_url = https://api.sentera.com
+
+[development]
+environment = development
+sentera_api_url = https://apidev.sentera.com
+
+[staging]
+environment = staging
+sentera_api_url = https://apistaging.sentera.com
+
+[staging2]
+environment = staging2
+sentera_api_url = https://apistaging2.sentera.com
+
+[production]
+environment = production

--- a/sentera/configuration.ini
+++ b/sentera/configuration.ini
@@ -1,21 +1,17 @@
 [DEFAULT]
 
 [development]
-environment = development
 sentera_api_url = https://apidev.sentera.com
 weather_api_url = https://weatherdev.sentera.com
 
 [production]
-environment = production
 sentera_api_url = https://api.sentera.com
 weather_api_url = https://weather.sentera.com
 
 [staging]
-environment = staging
 sentera_api_url = https://apistaging.sentera.com
 weather_api_url = https://weatherstaging.sentera.com
 
 [staging2]
-environment = staging2
 sentera_api_url = https://apistaging2.sentera.com
 weather_api_url = https://weatherstaging2.sentera.com

--- a/sentera/configuration.ini
+++ b/sentera/configuration.ini
@@ -15,3 +15,7 @@ weather_api_url = https://weatherstaging.sentera.com
 [staging2]
 sentera_api_url = https://apistaging2.sentera.com
 weather_api_url = https://weatherstaging2.sentera.com
+
+[test]
+sentera_api_url = https://apitest.sentera.com
+weather_api_url = https://weathertest.sentera.com

--- a/sentera/configuration.ini
+++ b/sentera/configuration.ini
@@ -17,5 +17,6 @@ sentera_api_url = https://apistaging2.sentera.com
 weather_api_url = https://weatherstaging2.sentera.com
 
 [test]
+# This environment is intended to be used by tests and is not a real environment.
 sentera_api_url = https://apitest.sentera.com
 weather_api_url = https://weathertest.sentera.com

--- a/sentera/configuration.py
+++ b/sentera/configuration.py
@@ -12,31 +12,46 @@ except ImportError:
     import importlib_resources as pkg_resources
 
 
-environment = os.environ.get("SENTERA_ENV") or "production"
-environment = environment.lower()
+class Configuration:
+    """Class toretrieve configurations from."""
 
-config_parser = configparser.ConfigParser()
-config_str = pkg_resources.read_text(sentera, "configuration.ini")
-config_parser.read_string(config_str)
+    def __init__(self, environment=None):
+        """
+        Initialize a configuration object. You can optionally pass in the environment.
 
-config = config_parser[environment]
+        Order precedence for environment:
+          environment argument
+          SENTERA_ENV environment variable
+          defaulting to production
 
+        :param environment: (optional) The environment you want configuations for.
+        :retun: **Configuration instance** - A configuration object for a given environment.
+        """
+        if environment is None:
+            environment = os.environ.get("SENTERA_ENV") or "production"
+            environment = environment.lower()
+        self.environment = environment
 
-def sentera_api_url(path):
-    """
-    Return a url to the Sentera API for the path supplied.
+        config_parser = configparser.ConfigParser()
+        config_str = pkg_resources.read_text(sentera, "configuration.ini")
+        config_parser.read_string(config_str)
 
-    :param path: The path to the weather service endpoint you would like to use.
-    :return: **url** - A url to the weather service with the path you provided.
-    """
-    return "{}{}".format(config["sentera_api_url"], path)
+        self.config = config_parser[environment]
 
+    def sentera_api_url(self, path):
+        """
+        Return a url to the Sentera API for the path supplied.
 
-def weather_api_url(path):
-    """
-    Return a url to the weather service for the path supplied.
+        :param path: The path to the weather service endpoint you would like to use.
+        :return: **url** - A url to the weather service with the path you provided.
+        """
+        return "{}{}".format(self.config["sentera_api_url"], path)
 
-    :param path: The path to the weather service endpoint you would like to use.
-    :return: **url** - A url to the weather service with the path you provided.
-    """
-    return "{}{}".format(config["weather_api_url"], path)
+    def weather_api_url(self, path):
+        """
+        Return a url to the weather service for the path supplied.
+
+        :param path: The path to the weather service endpoint you would like to use.
+        :return: **url** - A url to the weather service with the path you provided.
+        """
+        return "{}{}".format(self.config["weather_api_url"], path)

--- a/sentera/configuration.py
+++ b/sentera/configuration.py
@@ -1,4 +1,4 @@
-"""Evnironment specific configurations."""
+"""Environment specific configurations."""
 
 import configparser
 import os

--- a/sentera/configuration.py
+++ b/sentera/configuration.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 class Configuration:
-    """Class toretrieve configurations from."""
+    """Class to retrieve configurations from."""
 
     def __init__(self, environment=None):
         """

--- a/sentera/configuration.py
+++ b/sentera/configuration.py
@@ -1,0 +1,22 @@
+import configparser
+import os
+
+try:
+    import importlib.resources as pkg_resources
+except ImportError:
+    # Try backported to PY<37 `importlib_resources`.
+    import importlib_resources as pkg_resources
+
+import sentera
+
+environment = os.environ.get('SENTERA_ENV') or 'production'
+
+config_parser = configparser.ConfigParser()
+config_str = pkg_resources.read_text(sentera, 'configuration.ini')
+config_parser.read_string(config_str)
+
+print(config_parser.sections())
+config = config_parser[environment]
+
+def sentera_api_url(path):
+  return '{}{}'.format(config['sentera_api_url'], path)

--- a/sentera/configuration.py
+++ b/sentera/configuration.py
@@ -1,5 +1,9 @@
+"""Evnironment specific configurations."""
+
 import configparser
 import os
+
+import sentera
 
 try:
     import importlib.resources as pkg_resources
@@ -7,16 +11,32 @@ except ImportError:
     # Try backported to PY<37 `importlib_resources`.
     import importlib_resources as pkg_resources
 
-import sentera
 
-environment = os.environ.get('SENTERA_ENV') or 'production'
+environment = os.environ.get("SENTERA_ENV") or "production"
+environment = environment.lower()
 
 config_parser = configparser.ConfigParser()
-config_str = pkg_resources.read_text(sentera, 'configuration.ini')
+config_str = pkg_resources.read_text(sentera, "configuration.ini")
 config_parser.read_string(config_str)
 
-print(config_parser.sections())
 config = config_parser[environment]
 
+
 def sentera_api_url(path):
-  return '{}{}'.format(config['sentera_api_url'], path)
+    """
+    Return a url to the Sentera API for the path supplied.
+
+    :param path: The path to the weather service endpoint you would like to use.
+    :return: **url** - A url to the weather service with the path you provided.
+    """
+    return "{}{}".format(config["sentera_api_url"], path)
+
+
+def weather_api_url(path):
+    """
+    Return a url to the weather service for the path supplied.
+
+    :param path: The path to the weather service endpoint you would like to use.
+    :return: **url** - A url to the weather service with the path you provided.
+    """
+    return "{}{}".format(config["weather_api_url"], path)

--- a/sentera/tests/conftest.py
+++ b/sentera/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_test_env(monkeypatch):
+    monkeypatch.setenv("SENTERA_ENV", "test")

--- a/sentera/tests/test_auth.py
+++ b/sentera/tests/test_auth.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ..configuration import Configuration
+
+
+def test_default_configuration():
+    configuration = Configuration()
+    assert configuration.environment == "production"
+    assert configuration.sentera_api_url("/") == "https://api.sentera.com/"
+
+
+def test_development_configuration(monkeypatch):
+    monkeypatch.setenv("SENTERA_ENV", "development")
+    configuration = Configuration()
+    assert configuration.environment == "development"
+    assert configuration.sentera_api_url("/") == "https://apidev.sentera.com/"
+
+
+def test_argument_configuration(monkeypatch):
+    assert Configuration("staging").environment == "staging"

--- a/sentera/tests/test_auth.py
+++ b/sentera/tests/test_auth.py
@@ -1,20 +1,55 @@
+import json
+
+import httpretty
 import pytest
 
-from ..configuration import Configuration
+from ..auth import get_application_token, get_auth_token
 
 
-def test_default_configuration():
-    configuration = Configuration()
-    assert configuration.environment == "production"
-    assert configuration.sentera_api_url("/") == "https://api.sentera.com/"
+@httpretty.httprettified
+def test_get_application_token_success():
+    def request_callback(request, uri, response_headers):
+        assert (
+            request.headers["Authorization"]
+            == "Basic dGVzdF9jbGllbnRfaWRfMTIzOnRlc3RfY2xpZW50X3NlY3JldF8zMjE="
+        )
+        assert request.body == b"grant_type=client_credentials"
+        return [
+            200,
+            response_headers,
+            json.dumps(
+                {
+                    "access_token": "my-test-access-token-abc123",
+                    "token_type": "Bearer",
+                    "expires_in": 1800,
+                    "created_at": 1584561685,
+                }
+            ),
+        ]
+
+    httpretty.register_uri(
+        httpretty.POST, "https://apitest.sentera.com/oauth/token", body=request_callback
+    )
+    response = get_application_token("test_client_id_123", "test_client_secret_321")
+    assert response["access_token"] == "my-test-access-token-abc123"
+    assert len(httpretty.latest_requests()) == 1
 
 
-def test_development_configuration(monkeypatch):
-    monkeypatch.setenv("SENTERA_ENV", "development")
-    configuration = Configuration()
-    assert configuration.environment == "development"
-    assert configuration.sentera_api_url("/") == "https://apidev.sentera.com/"
+@httpretty.httprettified
+def test_get_auth_token_success():
+    def request_callback(request, uri, response_headers):
+        body_json = json.loads(request.body.decode("utf-8"))
+        assert body_json["session"]["email"] == "test@email.com"
+        assert body_json["session"]["password"] == "pass123"
+        return [
+            200,
+            response_headers,
+            json.dumps({"auth_token": "my-test-access-token-xyz098"}),
+        ]
 
-
-def test_argument_configuration(monkeypatch):
-    assert Configuration("staging").environment == "staging"
+    httpretty.register_uri(
+        httpretty.POST, "https://apitest.sentera.com/v1/sessions", body=request_callback
+    )
+    response = get_auth_token("test@email.com", "pass123")
+    assert response == "my-test-access-token-xyz098"
+    assert len(httpretty.latest_requests()) == 1

--- a/sentera/tests/test_configuration.py
+++ b/sentera/tests/test_configuration.py
@@ -3,7 +3,8 @@ import pytest
 from ..configuration import Configuration
 
 
-def test_default_configuration():
+def test_default_configuration(monkeypatch):
+    monkeypatch.delenv("SENTERA_ENV", raising=False)
     configuration = Configuration()
     assert configuration.environment == "production"
     assert configuration.sentera_api_url("/") == "https://api.sentera.com/"

--- a/sentera/tests/test_configuration.py
+++ b/sentera/tests/test_configuration.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ..configuration import Configuration
+
+
+def test_default_configuration():
+    configuration = Configuration()
+    assert configuration.environment == "production"
+    assert configuration.sentera_api_url("/") == "https://api.sentera.com/"
+
+
+def test_development_configuration(monkeypatch):
+    monkeypatch.setenv("SENTERA_ENV", "development")
+    configuration = Configuration()
+    assert configuration.environment == "development"
+    assert configuration.sentera_api_url("/") == "https://apidev.sentera.com/"
+
+
+def test_argument_configuration(monkeypatch):
+    assert Configuration("staging").environment == "staging"

--- a/sentera/weather.py
+++ b/sentera/weather.py
@@ -10,7 +10,6 @@ asynchronous manner by the ``sentera.api`` module.
 import asyncio
 import datetime
 import json
-import posixpath
 import re
 from enum import Enum
 
@@ -18,6 +17,8 @@ import aiohttp
 import pandas as pd
 import tqdm
 from pandas.io.json import json_normalize
+
+from sentera import configuration
 
 WEATHER_BASE_URL = "https://weather.sentera.com"
 WEATHER_HEADER = {"X-API-Key": "mc049Cu9FJ3lHiQYDYQTd3ZOzsOBt29d2gyi3e0r"}
@@ -124,7 +125,9 @@ def build_weather_url(weather_type, weather_variable, weather_interval, lat, lon
     :return: Constructed query URL, as string.
     """
     if weather_type == WeatherType.SevenDay:
-        return posixpath.join(WEATHER_BASE_URL, str(weather_type), str(lat), str(long),)
+        return configuration.weather_api_url(
+            "/{}/{}/{}".format(str(weather_type), str(lat), str(long))
+        )
 
     else:
         try:
@@ -138,12 +141,14 @@ def build_weather_url(weather_type, weather_variable, weather_interval, lat, lon
                 f"Parameter combination not allowed: {weather_type}, {weather_variable}, {weather_interval}"
             )
 
-        return posixpath.join(
-            WEATHER_BASE_URL,
-            str(weather_type),
-            f"{weather_interval}-{weather_variable}",
-            str(lat),
-            str(long),
+        return configuration.weather_api_url(
+            "/{}/{}-{}/{}/{}".format(
+                str(weather_type),
+                weather_interval,
+                weather_variable,
+                str(lat),
+                str(long),
+            )
         )
 
 
@@ -284,7 +289,7 @@ async def run_queries(
     time_interval_list,
     weather_interval,
     weather_type,
-    dtn_key=None,
+    sentera_api_key=None,
 ):
     """
     Make a series of asynchronous requests to the Weather API.
@@ -299,13 +304,13 @@ async def run_queries(
     :param time_interval_list: List of time intervals for each request
     :param weather_interval: List of weather intervals, as instances of the ``sentera.weather.WeatherInterval`` Enum
     :param weather_type: List of weather types, as instances of the ``sentera.weather.WeatherType`` Enum
-    :param dtn_key: (optional) A DTN key giving access to the data. Has a default hard coded value that works.
+    :param sentera_api_key: (optional) A Sentera key giving access to the data. Has a default hard coded value that works.
     :return: data_df: Pandas DataFrame of request results
     """
     tasks = []
 
-    if dtn_key:
-        WEATHER_HEADER["X-API-Key"] = dtn_key
+    if sentera_api_key:
+        WEATHER_HEADER["X-API-Key"] = sentera_api_key
 
     async with aiohttp.ClientSession(headers=WEATHER_HEADER) as session:
         for url, weather_variable, time_interval in zip(

--- a/sentera/weather.py
+++ b/sentera/weather.py
@@ -18,7 +18,7 @@ import pandas as pd
 import tqdm
 from pandas.io.json import json_normalize
 
-from sentera import configuration
+from sentera.configuration import Configuration
 
 WEATHER_BASE_URL = "https://weather.sentera.com"
 WEATHER_HEADER = {"X-API-Key": "mc049Cu9FJ3lHiQYDYQTd3ZOzsOBt29d2gyi3e0r"}
@@ -125,7 +125,7 @@ def build_weather_url(weather_type, weather_variable, weather_interval, lat, lon
     :return: Constructed query URL, as string.
     """
     if weather_type == WeatherType.SevenDay:
-        return configuration.weather_api_url(
+        return Configuration().weather_api_url(
             "/{}/{}/{}".format(str(weather_type), str(lat), str(long))
         )
 
@@ -141,7 +141,7 @@ def build_weather_url(weather_type, weather_variable, weather_interval, lat, lon
                 f"Parameter combination not allowed: {weather_type}, {weather_variable}, {weather_interval}"
             )
 
-        return configuration.weather_api_url(
+        return Configuration().weather_api_url(
             "/{}/{}-{}/{}/{}".format(
                 str(weather_type),
                 weather_interval,


### PR DESCRIPTION
# Title
[FA-988] add client request
## What?
Adding the ability to get a token based off of a CloudVault application client id and client secret.

If you run your application with a `SENTERA_ENV` environment variable, it will use that to determine the environment. Otherwise it currently defaults to production since we don't have a great setup for external customers to use anything else.
`SENTERA_ENV=development pipenv run python myalert.py`

## Why?
It can be used by application processes.

## QA Strategy
- [x] Merged latest master
- [x] Updated version number
- [x] Can get an access token based on client credentials
- [x] Can get an access token based on user credentials
- [x] Can create an alert
- [x] Can query for weather data

## Breaking Changes
- changed `dtn_key` to `sentera_api_key`