### PR TITLE
[FA-987] add alert key

### DIFF
--- a/sentera/_version.py
+++ b/sentera/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -109,6 +109,7 @@ def create_alert(field_sentera_id, name, message, token, key=None):
     :param name: name of the alert (string)
     :param message: brief description of the alert being made (string)
     :param token: an authorization token needed to post the alert to the specified field (string)
+    :param key: (optional) A client-defined key to help identify the alert.
     :return: result of the request.post
     """
     query = """mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -101,7 +101,7 @@ def get_weather(
     return weather_df
 
 
-def create_alert(field_sentera_id, name, message, token):
+def create_alert(field_sentera_id, name, message, token, key=None):
     """
     Create alert content and post alert mutation to https://api.sentera.com/graphql.
 
@@ -111,16 +111,18 @@ def create_alert(field_sentera_id, name, message, token):
     :param token: an authorization token needed to post the alert to the specified field (string)
     :return: result of the request.post
     """
-    query = """mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!) {
+    query = """mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {
     create_alert (
     field_sentera_id: $field_sentera_id
     name: $name
     message: $message
+    key: $key
     )
     {
     sentera_id
     name
     message
+    key
     created_by {
         sentera_id
         first_name
@@ -130,7 +132,12 @@ def create_alert(field_sentera_id, name, message, token):
         created_at
     }
 }"""
-    variables = {"field_sentera_id": field_sentera_id, "name": name, "message": message}
+    variables = {
+        "field_sentera_id": field_sentera_id,
+        "name": name,
+        "message": message,
+        "key": key,
+    }
     data = {"query": query, "variables": variables}
     result = _run_sentera_query(data, token)
 

--- a/sentera/tests/test_api.py
+++ b/sentera/tests/test_api.py
@@ -1,0 +1,83 @@
+import json
+
+import httpretty
+import pytest
+
+from ..api import create_alert
+
+
+@httpretty.httprettified
+def test_create_alert_with_key_success():
+    def request_callback(request, uri, response_headers):
+        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {\\n    create_alert ("
+        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "key": "corn_rust"}'
+        assert variables in request.body
+        assert mutation in request.body
+        return [
+            200,
+            response_headers,
+            json.dumps(
+                {
+                    "data": {
+                        "create_alert": {
+                            "sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
+                            "key": "corn_rust",
+                            "name": "Southern Corn Rust Alert",
+                            "message": "Current weather conditions indicate things.",
+                            "created_at": "2020-03-26T18:20:03Z",
+                        }
+                    }
+                }
+            ),
+        ]
+
+    httpretty.register_uri(
+        httpretty.POST, "https://apitest.sentera.com/graphql", body=request_callback
+    )
+    response = create_alert(
+        field_sentera_id="gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
+        name="Southern Corn Rust Alert",
+        message="Current weather conditions indicate things.",
+        token="token123",
+        key="corn_rust",
+    )
+    assert response["data"]["create_alert"]["key"] == "corn_rust"
+    assert len(httpretty.latest_requests()) == 1
+
+
+@httpretty.httprettified
+def test_create_alert_without_key_success():
+    def request_callback(request, uri, response_headers):
+        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {\\n    create_alert ("
+        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "key": null}'
+        assert variables in request.body
+        assert mutation in request.body
+        return [
+            200,
+            response_headers,
+            json.dumps(
+                {
+                    "data": {
+                        "create_alert": {
+                            "sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
+                            "key": None,
+                            "name": "Southern Corn Rust Alert",
+                            "message": "Current weather conditions indicate things.",
+                            "created_at": "2020-03-26T18:20:03Z",
+                        }
+                    }
+                }
+            ),
+        ]
+
+    httpretty.register_uri(
+        httpretty.POST, "https://apitest.sentera.com/graphql", body=request_callback
+    )
+    response = create_alert(
+        "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
+        "Southern Corn Rust Alert",
+        "Current weather conditions indicate things.",
+        "token123",
+    )
+    assert response["data"]["create_alert"]["key"] is None
+    assert len(httpretty.latest_requests()) == 1


### PR DESCRIPTION
# [FA-987] add alert key
## What?
Added the optional key parameter when creating an alert.
## Why?
Would like to use keys when creating alerts.
## QA Strategy
- [x] Merged latest master
- [x] Updated version number
- [x] Can create alerts with a key
- [x] Can create alerts without a key
## Breaking Changes
- None
