### PR TITLE
added url input to create alert function

### DIFF
--- a/sentera/_version.py
+++ b/sentera/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/sentera/_version.py
+++ b/sentera/_version.py
@@ -1,4 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
 __version__ = "2.3.0"
-

--- a/sentera/_version.py
+++ b/sentera/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -101,7 +101,7 @@ def get_weather(
     return weather_df
 
 
-def create_alert(field_sentera_id, name, message, token, url=None, key=None):
+def create_alert(field_sentera_id, name, message, token, key=None, url=None):
     """
     Create alert content and post alert mutation to https://api.sentera.com/graphql.
 
@@ -109,29 +109,29 @@ def create_alert(field_sentera_id, name, message, token, url=None, key=None):
     :param name: name of the alert (string)
     :param message: brief description of the alert being made (string)
     :param token: an authorization token needed to post the alert to the specified field (string)
-    :param url: (optional) url link to more information about the alert (string)
     :param key: (optional) A client-defined key to help identify the alert.
+    :param url: (optional) url link to more information about the alert (url)
     :return: result of the request.post
     """
     query = """mutation CreateAlert (
     $field_sentera_id: ID!,
     $name: String!,
     $message: String!,
-    $url: String,
-    $key: String) {
+    $key: String,
+    $url: Url) {
     create_alert (
     field_sentera_id: $field_sentera_id
     name: $name
     message: $message
-    url: $url
     key: $key
+    url: $url
     )
     {
     sentera_id
     name
     message
-    url
     key
+    url
     created_by {
         sentera_id
         first_name
@@ -145,8 +145,8 @@ def create_alert(field_sentera_id, name, message, token, url=None, key=None):
         "field_sentera_id": field_sentera_id,
         "name": name,
         "message": message,
-        "url": url,
         "key": key,
+        "url": url,
     }
     data = {"query": query, "variables": variables}
     result = _run_sentera_query(data, token)

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -109,7 +109,7 @@ def create_alert(field_sentera_id, name, message, token, url=None, key=None):
     :param name: name of the alert (string)
     :param message: brief description of the alert being made (string)
     :param token: an authorization token needed to post the alert to the specified field (string)
-    :param url: url link to more information about the alert (string)
+    :param url: (optional) url link to more information about the alert (string)
     :param key: (optional) A client-defined key to help identify the alert.
     :return: result of the request.post
     """
@@ -130,6 +130,7 @@ def create_alert(field_sentera_id, name, message, token, url=None, key=None):
     sentera_id
     name
     message
+    url
     key
     created_by {
         sentera_id

--- a/sentera/api.py
+++ b/sentera/api.py
@@ -101,7 +101,7 @@ def get_weather(
     return weather_df
 
 
-def create_alert(field_sentera_id, name, message, token, key=None):
+def create_alert(field_sentera_id, name, message, token, url=None, key=None):
     """
     Create alert content and post alert mutation to https://api.sentera.com/graphql.
 
@@ -109,14 +109,21 @@ def create_alert(field_sentera_id, name, message, token, key=None):
     :param name: name of the alert (string)
     :param message: brief description of the alert being made (string)
     :param token: an authorization token needed to post the alert to the specified field (string)
+    :param url: url link to more information about the alert (string)
     :param key: (optional) A client-defined key to help identify the alert.
     :return: result of the request.post
     """
-    query = """mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {
+    query = """mutation CreateAlert (
+    $field_sentera_id: ID!,
+    $name: String!,
+    $message: String!,
+    $url: String,
+    $key: String) {
     create_alert (
     field_sentera_id: $field_sentera_id
     name: $name
     message: $message
+    url: $url
     key: $key
     )
     {
@@ -137,6 +144,7 @@ def create_alert(field_sentera_id, name, message, token, key=None):
         "field_sentera_id": field_sentera_id,
         "name": name,
         "message": message,
+        "url": url,
         "key": key,
     }
     data = {"query": query, "variables": variables}

--- a/sentera/tests/test_api.py
+++ b/sentera/tests/test_api.py
@@ -10,8 +10,9 @@ from ..api import create_alert, get_weather
 @httpretty.httprettified
 def test_create_alert_with_key_success():
     def request_callback(request, uri, response_headers):
-        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $url: String, $key: String) {\\n    create_alert ("
-        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "url": "https://www.sentera.com", "key": "corn_rust"}'
+        mutation = b"mutation CreateAlert (\\n    $field_sentera_id: ID!,\\n    $name: String!,\\n    $message: String!,\\n    $key: String,\\n    $url: Url) {\\n    create_alert ("
+        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "key": "corn_rust", "url": "https://www.sentera.com"}'
+        print(request.body)
         assert variables in request.body
         assert mutation in request.body
         return [
@@ -23,9 +24,9 @@ def test_create_alert_with_key_success():
                         "create_alert": {
                             "sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
                             "key": "corn_rust",
-                            "url": "https://www.sentera.com",
                             "name": "Southern Corn Rust Alert",
                             "message": "Current weather conditions indicate things.",
+                            "url": "https://www.sentera.com",
                             "created_at": "2020-03-26T18:20:03Z",
                         }
                     }
@@ -41,8 +42,8 @@ def test_create_alert_with_key_success():
         name="Southern Corn Rust Alert",
         message="Current weather conditions indicate things.",
         token="token123",
-        url="https://www.sentera.com",
         key="corn_rust",
+        url="https://www.sentera.com",
     )
     assert response["data"]["create_alert"]["key"] == "corn_rust"
     assert len(httpretty.latest_requests()) == 1
@@ -51,8 +52,8 @@ def test_create_alert_with_key_success():
 @httpretty.httprettified
 def test_create_alert_without_key_success():
     def request_callback(request, uri, response_headers):
-        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $url: String, $key: String) {\\n    create_alert ("
-        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "url": null, "key": null}'
+        mutation = b"mutation CreateAlert (\\n    $field_sentera_id: ID!,\\n    $name: String!,\\n    $message: String!,\\n    $key: String,\\n    $url: Url) {\\n    create_alert ("
+        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "key": null, "url": null}'
         assert variables in request.body
         assert mutation in request.body
         return [
@@ -64,9 +65,9 @@ def test_create_alert_without_key_success():
                         "create_alert": {
                             "sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
                             "key": None,
-                            "url": None,
                             "name": "Southern Corn Rust Alert",
                             "message": "Current weather conditions indicate things.",
+                            "url": None,
                             "created_at": "2020-03-26T18:20:03Z",
                         }
                     }

--- a/sentera/tests/test_api.py
+++ b/sentera/tests/test_api.py
@@ -10,8 +10,8 @@ from ..api import create_alert, get_weather
 @httpretty.httprettified
 def test_create_alert_with_key_success():
     def request_callback(request, uri, response_headers):
-        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {\\n    create_alert ("
-        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "key": "corn_rust"}'
+        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $url: String, $key: String) {\\n    create_alert ("
+        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "url": "https://www.sentera.com", "key": "corn_rust"}'
         assert variables in request.body
         assert mutation in request.body
         return [
@@ -23,6 +23,7 @@ def test_create_alert_with_key_success():
                         "create_alert": {
                             "sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
                             "key": "corn_rust",
+                            "url": "https://www.sentera.com",
                             "name": "Southern Corn Rust Alert",
                             "message": "Current weather conditions indicate things.",
                             "created_at": "2020-03-26T18:20:03Z",
@@ -40,6 +41,7 @@ def test_create_alert_with_key_success():
         name="Southern Corn Rust Alert",
         message="Current weather conditions indicate things.",
         token="token123",
+        url="https://www.sentera.com",
         key="corn_rust",
     )
     assert response["data"]["create_alert"]["key"] == "corn_rust"
@@ -49,8 +51,8 @@ def test_create_alert_with_key_success():
 @httpretty.httprettified
 def test_create_alert_without_key_success():
     def request_callback(request, uri, response_headers):
-        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $key: String) {\\n    create_alert ("
-        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "key": null}'
+        mutation = b"mutation CreateAlert ($field_sentera_id: ID!, $name: String!, $message: String!, $url: String, $key: String) {\\n    create_alert ("
+        variables = b'"variables": {"field_sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003", "name": "Southern Corn Rust Alert", "message": "Current weather conditions indicate things.", "url": null, "key": null}'
         assert variables in request.body
         assert mutation in request.body
         return [
@@ -62,6 +64,7 @@ def test_create_alert_without_key_success():
                         "create_alert": {
                             "sentera_id": "gyq8ll6_AL_8brhbkSentera_CV_shar_e599fde_200326_182003",
                             "key": None,
+                            "url": None,
                             "name": "Southern Corn Rust Alert",
                             "message": "Current weather conditions indicate things.",
                             "created_at": "2020-03-26T18:20:03Z",


### PR DESCRIPTION
# <URL link in create alert>
## What?
You can now include a url in the create alert function that will attach a link to the alert.
## Why?
This will allow people to go learn more about the notification by clicking the link.
## PR Checklist
- [ ] Merged latest master
- [x] Updated version number
## Breaking Changes
