### PR TITLE
[FA-2521] Allow url config by env vars

### DIFF
--- a/sentera/_version.py
+++ b/sentera/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "2.6.2"
+__version__ = "2.6.3"

--- a/sentera/configuration.py
+++ b/sentera/configuration.py
@@ -2,29 +2,8 @@
 
 import os
 
-ENVIRONMENT_CONFIGS = {
-    "dev": {
-        "sentera_api_url": "https://apidev.sentera.com",
-        "weather_api_url": "https://weatherdev.sentera.com",
-    },
-    "prod": {
-        "sentera_api_url": "https://api.sentera.com",
-        "weather_api_url": "https://weather.sentera.com",
-    },
-    "staging": {
-        "sentera_api_url": "https://apistaging.sentera.com",
-        "weather_api_url": "https://weatherstaging.sentera.com",
-    },
-    "staging2": {
-        "sentera_api_url": "https://apistaging2.sentera.com",
-        "weather_api_url": "https://weatherstaging2.sentera.com",
-    },
-    "test": {
-        # This environment is intended to be used by tests and is not a real environment.
-        "sentera_api_url": "https://apitest.sentera.com",
-        "weather_api_url": "https://weathertest.sentera.com",
-    },
-}
+ENV_SENTERA_API_URL = "SENTERA_API_URL"
+ENV_WEATHER_API_URL = "WEATHER_API_URL"
 
 
 class Configuration:
@@ -47,7 +26,22 @@ class Configuration:
             environment = environment.lower()
         self.environment = environment
 
-        self.config = ENVIRONMENT_CONFIGS[environment]
+        if self.environment == "prod":
+            self.config = {
+                "sentera_api_url": "https://api.sentera.com",
+                "weather_api_url": "https://weather.sentera.com",
+            }
+        else:
+            self.config = {
+                "sentera_api_url": f"https://api{self.environment}.sentera.com",
+                "weather_api_url": f"https://weather{self.environment}.sentera.com",
+            }
+
+        if ENV_SENTERA_API_URL in os.environ:
+            self.config["sentera_api_url"] = os.environ.get(ENV_SENTERA_API_URL)
+
+        if ENV_WEATHER_API_URL in os.environ:
+            self.config["weather_api_url"] = os.environ.get(ENV_WEATHER_API_URL)
 
     def sentera_api_url(self, path):
         """

--- a/sentera/tests/test_configuration.py
+++ b/sentera/tests/test_configuration.py
@@ -8,6 +8,7 @@ def test_default_configuration(monkeypatch):
     configuration = Configuration()
     assert configuration.environment == "prod"
     assert configuration.sentera_api_url("/") == "https://api.sentera.com/"
+    assert configuration.weather_api_url("/") == "https://weather.sentera.com/"
 
 
 def test_development_configuration(monkeypatch):
@@ -15,6 +16,23 @@ def test_development_configuration(monkeypatch):
     configuration = Configuration()
     assert configuration.environment == "dev"
     assert configuration.sentera_api_url("/") == "https://apidev.sentera.com/"
+    assert configuration.weather_api_url("/") == "https://weatherdev.sentera.com/"
+
+
+def test_env_sentera_api_url_configuration(monkeypatch):
+    monkeypatch.setenv("SENTERA_API_URL", "https://example.com")
+    configuration = Configuration()
+    assert configuration.environment == "test"
+    assert configuration.sentera_api_url("/") == "https://example.com/"
+    assert configuration.weather_api_url("/") == "https://weathertest.sentera.com/"
+
+
+def test_env_weather_api_url_configuration(monkeypatch):
+    monkeypatch.setenv("WEATHER_API_URL", "https://weatherkazoo.sentera.com")
+    configuration = Configuration()
+    assert configuration.environment == "test"
+    assert configuration.sentera_api_url("/") == "https://apitest.sentera.com/"
+    assert configuration.weather_api_url("/") == "https://weatherkazoo.sentera.com/"
 
 
 def test_argument_configuration(monkeypatch):


### PR DESCRIPTION
## What?
Allowing url configuration by env variables.

## Why?
Would like to be able to send staging to a mock weather server without further code changes.

## Jira
https://sentera.atlassian.net/browse/FA-2521

## QA Checklist
- [x] Merged latest master
- [x] Updated version number
- [x] Can set sentera api url with SENTERA_API_URL env var
- [x] Can set weather api url with WEATHER_API_URL env var
- [x] Defaults work for sentera_api_url
- [x] Defaults work for weeather_api_url

## Breaking Changes
None